### PR TITLE
YALB-686: Bug: Error when user ID is null

### DIFF
--- a/yale_cas.module
+++ b/yale_cas.module
@@ -18,9 +18,7 @@ function yale_cas_form_user_form_alter(&$form, FormStateInterface $form_state, $
   $account = $form_state->getFormObject()->getEntity();
 
   // Look for a user id to ensure we do not alter the user-add form.
-  if(!empty($account->id())) {
-    $cas_username = $cas_user_manager->getCasUsernameForAccount($account->id());
-  }
+  $cas_username = empty($account->id()) ? '' : $cas_user_manager->getCasUsernameForAccount($account->id());
 
   // We want admins to have the 'administer account settings' permission,
   // but this allows editing of email and password for CAS users, so the

--- a/yale_cas.module
+++ b/yale_cas.module
@@ -16,7 +16,11 @@ function yale_cas_form_user_form_alter(&$form, FormStateInterface $form_state, $
   // Check for a CAS user using the same logic in cas.module.
   $cas_user_manager = \Drupal::service('cas.user_manager');
   $account = $form_state->getFormObject()->getEntity();
-  $cas_username = $cas_user_manager->getCasUsernameForAccount($account->id());
+
+  // Look for a user id to ensure we do not alter the user-add form.
+  if(!empty($account->id())) {
+    $cas_username = $cas_user_manager->getCasUsernameForAccount($account->id());
+  }
 
   // We want admins to have the 'administer account settings' permission,
   // but this allows editing of email and password for CAS users, so the


### PR DESCRIPTION
## [YALB-686: Bug: Error when user ID is null](https://yaleits.atlassian.net/browse/YALB-686)

### Description of work
- Checks if the user ID exists before altering the form. This prevents changes to the user-add form where the logic in the alter hook does not apply.

### Functional testing steps:
- [ ] Install the CAS module or update to this version. For the yalesites project...
  - [x] `cd web/profiles/custom/yalesites_profile/`
  - [x] `composer require "yalesites-org/yale_cas":"dev-YALB-686-add-form" --no-update`
  - [x] `cd ../../../..`
  - [x] `composer update`
- [ ] Visit the user-add form and verify that you can see the form. Previously this white-screened and threw and error.
