### PR TITLE
FIX: Drupal 11 drush commands Failing Due to Cas code Deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "drupal-module",
     "minimum-stability": "dev",
     "require": {
-        "drupal/cas_attributes": "^2.0@beta || ^3.0@beta",
-        "drupal/cas": "^2.0@beta || ^3.0@beta"
+        "drupal/cas_attributes": "^3.0",
+        "drupal/cas": "^3.0"
     }
 }

--- a/src/EventSubscriber/CasAttributesSubscriber.php
+++ b/src/EventSubscriber/CasAttributesSubscriber.php
@@ -34,7 +34,7 @@ class CasAttributesSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     $events = [];
-    $events[CasHelper::EVENT_PRE_REDIRECT][] = ['onCasPreRedirect'];
+    $events[CasPreRedirectEvent::class][] = ['onCasPreRedirect'];
 
     return $events;
   }


### PR DESCRIPTION

### Description of work
-  Updated yale_cas module to use fully-qualified event class name
- The cas module deprecated the usage of the Constant approvach so we need to update the Yale cas module to keep the integration running.

Documentation:
https://www.drupal.org/node/3462792


Issue:
While trying to run `drush updb` in a D11 site with started to see the following error(site also running up to date version of CAS module):

```
 [warning] The following event constants are deprecated: Drupal\cas\Service\CasHelper::EVENT_PRE_REDIRECT. Use the corresponding event class fully qualified names instead: Drupal\cas\Service\CasHelper::EVENT_PRE_REDIRECT -> Drupal\cas\Event\CasPreRedirectEvent. See https://www.drupal.org/node/3462792
 [error]  TypeError: Drupal\views\ViewExecutable::setRequest(): Argument #1 ($request) must be of type Symfony\Component\HttpFoundation\Request, null given, called in /var/www/html/web/core/modules/views/src/ViewExecutableFactory.php on line 79 in Drupal\views\ViewExecutable->setRequest() (line 1866 of /var/www/html/web/core/modules/views/src/ViewExecutable.php) #0 /var/www/html/web/core/modules/views/src/ViewExecutableFactory.php(79): Drupal\views\ViewExecutable->setRequest()
#1 /var/www/html/web/core/modules/views/src/Entity/View.php(126): Drupal\views\ViewExecutableFactory->get()
#2 /var/www/html/web/core/modules/views/src/EventSubscriber/RouteSubscriber.php(116): Drupal\views\Entity\View->getExecutable()
#3 [internal function]: Drupal\views\EventSubscriber\RouteSubscriber->routes()
#4 /var/www/html/web/core/lib/Drupal/Core/Routing/RouteBuilder.php(146): call_user_func()
#5 /var/www/html/web/core/lib/Drupal/Core/ProxyClass/Routing/RouteBuilder.php(83): Drupal\Core\Routing\RouteBuilder->rebuild()
#6 /var/www/html/web/core/includes/common.inc(473): Drupal\Core\ProxyClass\Routing\RouteBuilder->rebuild()
#7 /var/www/html/vendor/drush/drush/src/Commands/core/UpdateDBCommands.php(96): drupal_flush_all_caches()
#8 [internal function]: Drush\Commands\core\UpdateDBCommands->updatedb()
#9 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(276): call_user_func_array()
#10 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(212): Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback()
#11 /var/www/html/vendor/consolidation/annotated-command/src/CommandProcessor.php(175): Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter()
#12 /var/www/html/vendor/consolidation/annotated-command/src/AnnotatedCommand.php(387): Consolidation\AnnotatedCommand\CommandProcessor->process()
#13 /var/www/html/vendor/symfony/console/Command/Command.php(318): Consolidation\AnnotatedCommand\AnnotatedCommand->execute()
#14 /var/www/html/vendor/symfony/console/Application.php(1110): Symfony\Component\Console\Command\Command->run()
#15 /var/www/html/vendor/symfony/console/Application.php(359): Symfony\Component\Console\Application->doRunCommand()
#16 /var/www/html/vendor/symfony/console/Application.php(194): Symfony\Component\Console\Application->doRun()
#17 /var/www/html/vendor/drush/drush/src/Runtime/Runtime.php(110): Symfony\Component\Console\Application->run()
#18 /var/www/html/vendor/drush/drush/src/Runtime/Runtime.php(40): Drush\Runtime\Runtime->doRun()
#19 /var/www/html/vendor/drush/drush/drush.php(140): Drush\Runtime\Runtime->run()
#20 {main}. 
```

### Functional testing steps:
- [ ] Install the module in a D11 site and also update the CAS module to the last version
- [ ] Now run the`drush updb` command, there should not be any errors.
